### PR TITLE
fix text baseline alignment on bottom bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+* Fix baseline alignment of text on the bottom bar.
+
 ## 1.4.3
 
 * Fix a bug where bottom tabs's count won't be updated on pane change unless lint is triggered.

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -102,6 +102,8 @@ linter-bottom-tab {
   background: fade(@button-background-color, 33%);
   cursor: pointer;
   vertical-align: middle;
+  position: relative;
+  top: -2px;
   &:first-of-type {
     border-top-left-radius: @component-border-radius;
     border-bottom-left-radius: @component-border-radius;


### PR DESCRIPTION
line up the baseline of the text inside the two bottom tabs with the text outside it.

See screenshot of change, with an XScope horizontal guide to show the alignment

![Screenshot of change](https://www.dropbox.com/s/3heszqvulxi51b4/Screenshot%202015-08-18%2015.17.04.png?dl=1)
